### PR TITLE
Optimize get_user_group_values call

### DIFF
--- a/rest_access_policy/access_policy.py
+++ b/rest_access_policy/access_policy.py
@@ -78,7 +78,7 @@ class AccessPolicy(permissions.BasePermission):
         self, request, statements: List[dict]
     ) -> List[dict]:
         user = request.user
-        user_roles = self.get_user_group_values(user)
+        user_roles = None
         matched = []
 
         for statement in statements:
@@ -94,6 +94,9 @@ class AccessPolicy(permissions.BasePermission):
             elif self.id_prefix + str(user.id) in principals:
                 found = True
             else:
+                if not user_roles:
+                    user_roles = self.get_user_group_values(user)
+
                 for user_role in user_roles:
                     if self.group_prefix + user_role in principals:
                         found = True


### PR DESCRIPTION
This is a small patch that optimizes the calling behavior for `get_user_group_values`. Instead of querying for the user groups immediately, it will only do so if no other principals could be found and if `user_roles` has not already been initialized.