### PR TITLE
Update access_view_set_mixin.py

### DIFF
--- a/rest_access_policy/access_view_set_mixin.py
+++ b/rest_access_policy/access_view_set_mixin.py
@@ -26,3 +26,10 @@ class AccessViewSetMixin(object):
     def finalize_response(self, request, response, *args, **kwargs) -> Response:
         response = super().finalize_response(request, response, *args, **kwargs)
         return response
+    
+    def get_queryset(self):
+        queryset = super().get_queryset()
+        scope_queryset = self.access_policy.scope_queryset(self.request, queryset)
+        if scope_queryset.exists():
+            return scope_queryset
+        return queryset


### PR DESCRIPTION
Included get_queryset method to return the scope_queryset if it has been explicity declared in the access_policy.
It calls super().get_queryset() instead of directly self.queryset to allow work with anothers mixins.
That way, won't be necessary to call the scope_queryset everytime in the view.