### PR TITLE
Removes unintentional shared state on boolOperand which was causing #83

### DIFF
--- a/rest_access_policy/access_policy.py
+++ b/rest_access_policy/access_policy.py
@@ -8,7 +8,7 @@ from rest_framework import permissions
 
 from rest_access_policy import AccessPolicyException
 
-from .parsing import BoolAnd, BoolNot, BoolOr, ConditionOperand, boolOperand
+from .parsing import BoolAnd, BoolNot, BoolOr, ConditionOperand, BoolOperand
 
 
 class AnonymousUser(object):
@@ -201,6 +201,8 @@ class AccessPolicy(permissions.BasePermission):
                 continue
 
             fails = 0
+
+            boolOperand = BoolOperand()
 
             for condition in conditions:
                 if is_expression:

--- a/rest_access_policy/parsing.py
+++ b/rest_access_policy/parsing.py
@@ -62,4 +62,8 @@ class BoolNot(object):
 
 TRUE = Keyword("True")
 FALSE = Keyword("False")
-boolOperand = TRUE | FALSE | Word(alphanums + '_:.*', max=256)
+
+
+class BoolOperand(object):
+    def __new__(cls):
+        return TRUE | FALSE | Word(alphanums + '_:.*', max=256)

--- a/test_project/testapp/tests/test_access_policy.py
+++ b/test_project/testapp/tests/test_access_policy.py
@@ -436,7 +436,7 @@ class AccessPolicyTests(TestCase):
             ],
         )
 
-    @mock.patch("rest_access_policy.access_policy.boolOperand")
+    @mock.patch("rest_access_policy.access_policy.BoolOperand")
     def test_complex_condition_parser_not_called_for_simple_condition(self, opMock):
         opMock.setParseAction = mock.MagicMock()
 


### PR DESCRIPTION
Fixes https://github.com/rsinger86/drf-access-policy/issues/83

I've been able to test this only in a private project and not with tests. However, "refreshing the page 100+ times" did not show any problems, while before this fix there was a good 90% chance to bump into it.

 Comment https://github.com/rsinger86/drf-access-policy/issues/83#issuecomment-1153285628 pointed out the problem perfectly.