### PR TITLE
Create PEP 561 compatible package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,7 @@ setup(
     author="Robert Singer",
     author_email="robertgsinger@gmail.com",
     packages=["rest_access_policy"],
+    package_data={"rest_access_policy": ["py.typed"]},
     url="https://github.com/rsinger86/drf-access-policy",
     license="MIT",
     keywords="django restframework drf access policy authorization declaritive",


### PR DESCRIPTION
Add `py.typed` to create a PEP 561 compatible package as described in [mypy's documentation](https://mypy.readthedocs.io/en/stable/installed_packages.html#creating-pep-561-compatible-packages).