### PR TITLE
DOCS: remove mistyped "self" argument in a module level function

### DIFF
--- a/docs/reusable_conditions.md
+++ b/docs/reusable_conditions.md
@@ -15,7 +15,7 @@ def is_the_weather_nice(request, view, action: str) -> bool:
     data = weather_api.load_today()
     return data["temperature"] > 68
 
-def user_must_be(self, request, view, action, field: str) -> bool:
+def user_must_be(request, view, action, field: str) -> bool:
     account = view.get_object()
     return getattr(account, field) == request.user
 ```


### PR DESCRIPTION
Hi, I've removed a minor typo from the docs. It was causing an error in my project, since I just copied it from the docs without checking :P